### PR TITLE
Fix mount point URLs for the original video to work in both local and deployed environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,32 @@ deployed to Cloud Run. Keep in mind that much of the processing will then happen
 locally, so the performance of the app will be directly related to the computer
 you are using.
 
+### Local Development Setup for GCS Uploads
+
+When running locally, uploading videos to GCS may fail due to CORS or permission issues. Follow these steps to resolve them:
+
+#### 1. Service Account Impersonation (No Keys Needed)
+To allow the local server to generate signed URLs for GCS uploads without using service account keys:
+1. Ensure your user account has the **Service Account Token Creator** role (`roles/iam.serviceAccountTokenCreator`) on the target service account.
+2. Authenticate locally:
+   ```bash
+   gcloud auth application-default login
+   ```
+3. The `run_locally.sh` script automatically exports `GCP_SERVICE_ACCOUNT_EMAIL` based on your `configuration.yaml`.
+
+#### 2. Update Bucket CORS for Localhost
+To allow uploads from `localhost`, you must update the CORS configuration of your GCS bucket without overwriting the production URLs:
+
+1. Fetch the current CORS configuration:
+   ```bash
+   gsutil cors get gs://YOUR_BUCKET_NAME > current_cors.json
+   ```
+2. Edit `current_cors.json` and add `"http://localhost:8080"` (and `"http://localhost:4200"` if applicable) to the `origin` list.
+3. Apply the updated configuration:
+   ```bash
+   gcloud storage buckets update gs://YOUR_BUCKET_NAME --cors-file=current_cors.json
+   ```
+
 `setup.sh` will create the file `configuration.yaml`, which the solution uses to
 configure things like the GCP project to use when sending requests to Gemini,
 the GCS buckets to use, and the like, as well as apply the necessary roles to

--- a/cloud_storage.py
+++ b/cloud_storage.py
@@ -207,6 +207,9 @@ def fetch_service_account_email() -> str:
   Returns:
     The service account email address.
   """
+  if "GCP_SERVICE_ACCOUNT_EMAIL" in os.environ:
+    return os.environ["GCP_SERVICE_ACCOUNT_EMAIL"]
+
   service_account_email = ""
   try:
     credentials, _ = typing.cast(tuple[Credentials, str], google.auth.default())

--- a/main.py
+++ b/main.py
@@ -351,18 +351,12 @@ def process_video(
 
     metadata["name"] = clean_video_name(video_name)
     metadata["duration"] = duration
-    if "K_SERVICE" in os.environ:
-      metadata["url"] = ""
-      metadata["download_url"] = ""
-      metadata["original_video_url"] = (
-          f"{to_return.video_id}/{to_return.video_id}"
-      )
-    else:
-      metadata["url"] = ""
-      metadata["download_url"] = ""
-      metadata["original_video_url"] = (
-          f"{mount_point}/{to_return.video_id}/{to_return.video_id}"
-      )
+    metadata["url"] = ""
+    metadata["download_url"] = ""
+    mount_path = mount_point.lstrip("/")
+    metadata["original_video_url"] = (
+        f"/{mount_path}/{to_return.video_id}/{to_return.video_id}"
+    )
     metadata["created_at"] = str(datetime.datetime.now())
     metadata["has_metadata"] = True
 
@@ -482,14 +476,10 @@ def generate_video(request: GenerateVideoRequest) -> JSONResponse:
     metadata["name"] = (
         f"{clean_video_name(video_data.video_id)}.{video_data.translate_language}.mp4"
     )
-    if "K_SERVICE" in os.environ:
-      metadata["original_video_url"] = (
-          f"{video_data.video_id}/{video_data.video_id}"
-      )
-    else:
-      metadata["original_video_url"] = (
-          f"{mount_point}/{video_data.video_id}/{video_data.video_id}"
-      )
+    mount_path = mount_point.lstrip("/")
+    metadata["original_video_url"] = (
+        f"/{mount_path}/{video_data.video_id}/{video_data.video_id}"
+    )
 
     if "K_SERVICE" in os.environ:
       # Upload the final video to GCS

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -24,4 +24,10 @@ if config:
     print(f"export {k}=\"{v}\"")' < configuration.yaml)
 fi
 
+# Export service account email for local impersonation
+if [ -n "$GCP_PROJECT_ID" ]; then
+  export GCP_SERVICE_ACCOUNT_EMAIL="ariel-v2@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+  echo "💡 Exported GCP_SERVICE_ACCOUNT_EMAIL=${GCP_SERVICE_ACCOUNT_EMAIL}"
+fi
+
 uv run uvicorn main:app --host 0.0.0.0 --port 8080 --reload


### PR DESCRIPTION
A previous change to how videos are uploaded broke the original video URL in the metadata. It's now the same for both local and deployed environments. We also require the single leading slash.

Also fixed cloud_strorage to use a local service account if it's exported to allow running locally. 

Also updated the run_locally script to export the service account email so it can be used.

Also updated the README with instructions on how to ensure the GCS bucket can be used when running locally.