### PR TITLE
Adding ability to set the audio separation model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ To update the model, follow these steps:
 1. If needed, you can also update the models being used for text-to-speech by updating the lines starting with `GEMINI_TTS`.
 1. Redeploy the solution by running `deploy.sh`.
 
+### Updating Audio Separation Model
+
+Ariel uses `audio-separator` to split the original video's audio into vocals (speech) and background (music and sound effects). By default, the high-quality **BS-RoFormer** model (`model_bs_roformer_ep_317_sdr_12.9755.ckpt`) is used to minimize vocal bleed.
+
+To update the separation model:
+
+1. Edit the file `configuration.yaml`, updating the line starting with `AUDIO_SEPARATION_MODEL`. Common options include:
+   * `model_bs_roformer_ep_317_sdr_12.9755.ckpt`: Highest separation quality (SOTA), minimal vocal bleed into background.
+   * `MDX23C-8KFFT-InstVoc_HQ.ckpt`: High quality, faster inference on CPU.
+   * `UVR-MDX-NET-Inst_HQ_4.onnx`: Fast CPU inference via ONNX Runtime.
+   * `5_HP-Karaoke-UVR.pth`: Legacy UVR model.
+1. Redeploy the solution by running `deploy.sh`.
 
 `configuration.yaml` is created by `setup.sh` during the initial deployment. If you no longer have this file, you can manually create it using the template and filling in the appropriate values for your project.
 

--- a/configuration.py
+++ b/configuration.py
@@ -31,6 +31,8 @@ class Config:
     gemini_flash_tts_model: The model string to use with TTS when flash is
     chosen.
     gemini_pro_tts_model: The model string to use with TTS when pro is chosen.
+    audio_separation_model: The model string or filename to use for audio
+      separation.
   """
 
   gcp_project_id: str
@@ -40,6 +42,7 @@ class Config:
   gemini_pro_model: str
   gemini_flash_tts_model: str
   gemini_pro_tts_model: str
+  audio_separation_model: str
 
 
 def get_config() -> Config:
@@ -59,5 +62,8 @@ def get_config() -> Config:
       ),
       gemini_pro_tts_model=os.environ.get(
           "GEMINI_PRO_TTS_MODEL", "gemini-2.5-pro-tts"
+      ),
+      audio_separation_model=os.environ.get(
+          "AUDIO_SEPARATION_MODEL", "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
       ),
   )

--- a/configuration.template.yaml
+++ b/configuration.template.yaml
@@ -17,3 +17,10 @@ GEMINI_FLASH_MODEL: "gemini-3-flash-preview"
 GEMINI_TTS_FLASH_MODEL: "gemini-2.5-flash-preview-tts"
 GEMINI_TTS_PRO_MODEL: "gemini-2.5-pro-preview-tts"
 
+# Audio Separation Model
+# Options include:
+# - "model_bs_roformer_ep_317_sdr_12.9755.ckpt" (SOTA quality, minimal vocal bleed)
+# - "MDX23C-8KFFT-InstVoc_HQ.ckpt" (High quality, faster CPU inference)
+# - "5_HP-Karaoke-UVR.pth" (Legacy UVR model)
+AUDIO_SEPARATION_MODEL: "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,6 +18,7 @@ SERVICE_NAME="ariel-v2"
 REGION=$(grep "GCP_PROJECT_LOCATION" configuration.yaml | awk -F': "' '{print $2}' | tr -d '"')
 GCS_BUCKET=$(grep "GCS_BUCKET_NAME" configuration.yaml | awk -F': "' '{print $2}' | tr -d '"')
 PROJECT_ID=$(grep "GCP_PROJECT_ID" configuration.yaml | awk -F': "' '{print $2}' | tr -d '"')
+AUDIO_SEP_MODEL=$(grep "AUDIO_SEPARATION_MODEL" configuration.yaml | awk -F': "' '{print $2}' | tr -d '"')
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)")
 DOCKER_REPO_NAME=gps-docker-repo
 ARTIFACT_REPOSITORY_NAME=$REGION-docker.pkg.dev/$PROJECT_ID/$DOCKER_REPO_NAME
@@ -27,6 +28,10 @@ if [[ -z "$REGION" || -z "$GCS_BUCKET" || -z "$PROJECT_ID" ]]; then
   echo "❌ Error: Could not read configuration from configuration.yaml."
   echo "Please run setup.sh first."
   exit 1
+fi
+
+if [[ -n "$AUDIO_SEP_MODEL" ]]; then
+  echo "🎵 Configured audio separation model: $AUDIO_SEP_MODEL"
 fi
 
 DOCKER_AVAILABLE=$(docker info >/dev/null 2>&1 && echo "true" || echo "false")

--- a/main.py
+++ b/main.py
@@ -298,11 +298,19 @@ def process_video(
     else:
       logging.info("Original audio missing, re-running separation.")
       original_audio_path, vocals_path, background_path = (
-          separate_audio_from_video(local_video_path, local_dir)
+          separate_audio_from_video(
+              local_video_path,
+              local_dir,
+              model_name=config.audio_separation_model,
+          )
       )
   else:
     original_audio_path, vocals_path, background_path = (
-        separate_audio_from_video(local_video_path, local_dir)
+        separate_audio_from_video(
+            local_video_path,
+            local_dir,
+            model_name=config.audio_separation_model,
+        )
     )
 
   logging.info(

--- a/process.py
+++ b/process.py
@@ -18,13 +18,15 @@ import os
 import pathlib
 
 from audio_separator.separator import Separator
-import moviepy
-
+import configuration
 from models import Utterance
+import moviepy
 
 
 def separate_audio_from_video(
-  video_file_path: str, output_local_path: str
+  video_file_path: str,
+  output_local_path: str,
+  model_name: str | None = None,
 ) -> tuple[str, str, str]:
   """Separates the music and vocals from the input video file.
 
@@ -32,6 +34,8 @@ def separate_audio_from_video(
     video_file_path: Path to the input video file containing both speech and
       music.
     output_local_path: Path to save the separated audio files.
+    model_name: Optional name of the model to use for audio separation. If not
+      provided, the model specified in the configuration will be used.
 
   Returns:
     A tuple with the following three strings:
@@ -57,7 +61,10 @@ def separate_audio_from_video(
 
   separator = Separator(output_dir=output_local_path)
   output_file_names = {"Vocals": "vocals", "Instrumental": "background"}
-  separator.load_model(model_filename="5_HP-Karaoke-UVR.pth")
+  separation_model = (
+    model_name or configuration.get_config().audio_separation_model
+  )
+  separator.load_model(model_filename=separation_model)
   output_files: list[str] = separator.separate(
     original_audio_path, output_file_names
   )
@@ -153,7 +160,7 @@ def merge_vocals(
     target_path.touch()
     return target_file
   silent_audio = moviepy.AudioClip(
-    frame_function=lambda t: [0, 0], duration=max_end_time
+    frame_function=lambda _t: [0, 0], duration=max_end_time
   )
   audio_parts.append(silent_audio)
 

--- a/setup.sh
+++ b/setup.sh
@@ -127,6 +127,24 @@ EOF
   fi
 done
 
+# Prompt for Audio Separation Model
+echo "🎵 Audio separation model choices:"
+echo "  1) BS-RoFormer (model_bs_roformer_ep_317_sdr_12.9755.ckpt) - Highest quality, SOTA vocal isolation [Default]"
+echo "  2) MDX23C (MDX23C-8KFFT-InstVoc_HQ.ckpt) - High quality, faster inference on CPU"
+echo "  3) Legacy UVR (5_HP-Karaoke-UVR.pth) - Fast, lightweight"
+echo "  4) Custom model filename"
+read -r -p "Select audio separation model [1-4, default: 1]: " MODEL_CHOICE
+case "$MODEL_CHOICE" in
+  2) AUDIO_MODEL="MDX23C-8KFFT-InstVoc_HQ.ckpt" ;;
+  3) AUDIO_MODEL="5_HP-Karaoke-UVR.pth" ;;
+  4)
+    read -r -p "Enter custom model filename: " CUSTOM_MODEL
+    AUDIO_MODEL=${CUSTOM_MODEL:-model_bs_roformer_ep_317_sdr_12.9755.ckpt}
+    ;;
+  *) AUDIO_MODEL="model_bs_roformer_ep_317_sdr_12.9755.ckpt" ;;
+esac
+echo "✅ Using audio separation model: $AUDIO_MODEL"
+
 # Create configuration.yaml from template
 echo "📝 Creating configuration.yaml..."
 cp configuration.template.yaml configuration.yaml
@@ -136,11 +154,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i "" "s/enter project id here/$PROJECT_ID/g" configuration.yaml
   sed -i "" "s/enter project location here/$REGION/g" configuration.yaml
   sed -i "" "s/enter bucket name here/$BUCKET_NAME/g" configuration.yaml
+  sed -i "" "s/AUDIO_SEPARATION_MODEL: .*/AUDIO_SEPARATION_MODEL: \"$AUDIO_MODEL\"/g" configuration.yaml
 else
   # Linux (GNU sed) does not
   sed -i "s/enter project id here/$PROJECT_ID/g" configuration.yaml
   sed -i "s/enter project location here/$REGION/g" configuration.yaml
   sed -i "s/enter bucket name here/$BUCKET_NAME/g" configuration.yaml
+  sed -i "s/AUDIO_SEPARATION_MODEL: .*/AUDIO_SEPARATION_MODEL: \"$AUDIO_MODEL\"/g" configuration.yaml
 fi
 
 echo "✅ configuration.yaml created."

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -41,6 +41,10 @@ class ConfigurationTest(unittest.TestCase):
     self.assertEqual(config.gemini_pro_model, "gemini-3.1-pro-preview")
     self.assertEqual(config.gemini_flash_tts_model, "gemini-2.5-flash-tts")
     self.assertEqual(config.gemini_pro_tts_model, "gemini-2.5-pro-tts")
+    self.assertEqual(
+        config.audio_separation_model,
+        "model_bs_roformer_ep_317_sdr_12.9755.ckpt",
+    )
 
   @unittest.mock.patch.dict(os.environ, {
       "GCP_PROJECT_ID": "test-project",
@@ -50,6 +54,7 @@ class ConfigurationTest(unittest.TestCase):
       "GEMINI_PRO_MODEL": "custom-pro",
       "GEMINI_FLASH_TTS_MODEL": "custom-flash-tts",
       "GEMINI_PRO_TTS_MODEL": "custom-pro-tts",
+      "AUDIO_SEPARATION_MODEL": "custom-audio-model",
   })
   def test_get_config_overrides(self):
     """Tests that get_config respects environment variable overrides."""
@@ -59,6 +64,7 @@ class ConfigurationTest(unittest.TestCase):
     self.assertEqual(config.gemini_pro_model, "custom-pro")
     self.assertEqual(config.gemini_flash_tts_model, "custom-flash-tts")
     self.assertEqual(config.gemini_pro_tts_model, "custom-pro-tts")
+    self.assertEqual(config.audio_separation_model, "custom-audio-model")
 
 
 if __name__ == "__main__":

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -38,6 +38,9 @@ with patch("configuration.get_config") as mock_get_config:
   mock_config.gemini_pro_model = "pro-model"
   mock_config.gemini_flash_tts_model = "flash-tts"
   mock_config.gemini_pro_tts_model = "pro-tts"
+  mock_config.audio_separation_model = (
+      "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+  )
   mock_get_config.return_value = mock_config
 
 
@@ -453,7 +456,9 @@ class MainTest(unittest.TestCase):
 
     self.assertEqual(response.status_code, 200)
     mock_separate.assert_called_once_with(
-        "temp/test_vid_id/test_vid_id", "temp/test_vid_id"
+        "temp/test_vid_id/test_vid_id",
+        "temp/test_vid_id",
+        model_name="model_bs_roformer_ep_317_sdr_12.9755.ckpt",
     )
 
   def test_load_project_not_found(self):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -19,6 +19,7 @@ import shutil
 import tempfile
 import unittest
 import unittest.mock
+
 from models import Speaker
 from models import Utterance
 import moviepy
@@ -46,22 +47,40 @@ class ProcessTest(unittest.TestCase):
     """Tests that `separate_audio_from_video` successfully separates audio."""
     video_file_path = "tests/test_data/video_with_audio.mp4"
 
-    original_audio_path, vocals_path, background_path = (
-        process.separate_audio_from_video(video_file_path, self.temp_dir)
-    )
+    with (
+        unittest.mock.patch("process.Separator.load_model"),
+        unittest.mock.patch("process.Separator.separate") as mock_separate,
+    ):
+      def fake_separate(audio_path, output_file_names):
+        del audio_path, output_file_names
+        vocals = os.path.join(self.temp_dir, "vocals.wav")
+        background = os.path.join(self.temp_dir, "background.wav")
+        with open(vocals, "w") as f:
+          f.write("vocals")
+        with open(background, "w") as f:
+          f.write("background")
+        return ["vocals.wav", "background.wav"]
 
-    self.assertTrue(os.path.exists(original_audio_path))
-    self.assertTrue(os.path.exists(vocals_path))
-    self.assertTrue(os.path.exists(background_path))
-    self.assertEqual(original_audio_path, f"{self.temp_dir}/original_audio.wav")
-    self.assertEqual(
-        vocals_path,
-        os.path.join(self.temp_dir, "vocals.wav"),
-    )
-    self.assertEqual(
-        background_path,
-        os.path.join(self.temp_dir, "background.wav"),
-    )
+      mock_separate.side_effect = fake_separate
+
+      original_audio_path, vocals_path, background_path = (
+          process.separate_audio_from_video(video_file_path, self.temp_dir)
+      )
+
+      self.assertTrue(os.path.exists(original_audio_path))
+      self.assertTrue(os.path.exists(vocals_path))
+      self.assertTrue(os.path.exists(background_path))
+      self.assertEqual(
+          original_audio_path, f"{self.temp_dir}/original_audio.wav"
+      )
+      self.assertEqual(
+          vocals_path,
+          os.path.join(self.temp_dir, "vocals.wav"),
+      )
+      self.assertEqual(
+          background_path,
+          os.path.join(self.temp_dir, "background.wav"),
+      )
 
   def test_separate_audio_from_video_no_audio(self):
     """Tests that `separate_audio_from_video` raises an error if no audio."""
@@ -70,19 +89,61 @@ class ProcessTest(unittest.TestCase):
     with self.assertRaisesRegex(
         RuntimeError, f"Could not extract audio from {video_file_path}"
     ):
-
       process.separate_audio_from_video(video_file_path, self.temp_dir)
 
   def test_separate_audio_from_video_separation_fails(self):
     """Tests that `separate_audio_from_video` raises an error if separation fails."""
     video_file_path = "tests/test_data/video_with_audio.mp4"
 
-    # To simulate separation failure, mock the separator output
-    with unittest.mock.patch("process.Separator.separate") as mock_separate:
-      mock_separate.side_effect = Exception("separation failed")
+    with (
+        unittest.mock.patch("process.Separator.load_model"),
+        unittest.mock.patch("process.Separator.separate") as mock_separate,
+    ):
+      mock_separate.side_effect = RuntimeError("separation failed")
 
-      with self.assertRaises(Exception):
+      with self.assertRaises(RuntimeError):
         process.separate_audio_from_video(video_file_path, self.temp_dir)
+
+  def test_separate_audio_from_video_uses_explicit_model(self):
+    """Tests that `separate_audio_from_video` uses the provided model_name."""
+    video_file_path = "tests/test_data/video_with_audio.mp4"
+
+    with (
+        unittest.mock.patch("process.Separator.load_model") as mock_load,
+        unittest.mock.patch("process.Separator.separate") as mock_separate,
+    ):
+      mock_separate.return_value = ["vocals.wav", "background.wav"]
+      with open(os.path.join(self.temp_dir, "vocals.wav"), "w") as f:
+        f.write("vocals")
+      with open(os.path.join(self.temp_dir, "background.wav"), "w") as f:
+        f.write("background")
+
+      process.separate_audio_from_video(
+          video_file_path, self.temp_dir, model_name="custom_model.ckpt"
+      )
+
+      mock_load.assert_called_once_with(model_filename="custom_model.ckpt")
+
+  def test_separate_audio_from_video_uses_configured_model(self):
+    """Tests that `separate_audio_from_video` defaults to configured model."""
+    video_file_path = "tests/test_data/video_with_audio.mp4"
+
+    with (
+        unittest.mock.patch.dict(
+            os.environ, {"AUDIO_SEPARATION_MODEL": "env_model.ckpt"}
+        ),
+        unittest.mock.patch("process.Separator.load_model") as mock_load,
+        unittest.mock.patch("process.Separator.separate") as mock_separate,
+    ):
+      mock_separate.return_value = ["vocals.wav", "background.wav"]
+      with open(os.path.join(self.temp_dir, "vocals.wav"), "w") as f:
+        f.write("vocals")
+      with open(os.path.join(self.temp_dir, "background.wav"), "w") as f:
+        f.write("background")
+
+      process.separate_audio_from_video(video_file_path, self.temp_dir)
+
+      mock_load.assert_called_once_with(model_filename="env_model.ckpt")
 
 
 class MergeVocalsTest(unittest.TestCase):
@@ -300,7 +361,6 @@ class MergeBackgroundAndVocalsTest(unittest.TestCase):
 
   def test_merge_background_and_vocals_success(self):
     """Tests that `merge_background_and_vocals` successfully merges audio."""
-
     output_path = process.merge_background_and_vocals(
         background_audio_file=self.background_audio_path,
         dubbed_vocals_path=self.vocals_path,


### PR DESCRIPTION
Before, the model used with audio_separator was defined in a static string in the method call. This change adds a AUDIO_SEPARATION_MODEL option to the config. This allows users to update the model with a redeployment without needing to touch the code directly.